### PR TITLE
Don't always be default

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,7 +15,7 @@ function makePlugin(utils: PluginUtils) {
   const customPlugin: PlaygroundPlugin = {
     id: ID,
     displayName: DISPLAY_NAME,
-    shouldBeSelected: () => true,
+    shouldBeSelected: () => false,
     didMount(sandbox, container) {
       // Mount the react app and pass the sandbox and container to the Provider wrapper to set up context.
       ReactDOM.render(


### PR DESCRIPTION
You could maybe change this to be true if there's a specific query, but it shouldn't always be taking the selection (or people will uninstall it quickly)